### PR TITLE
회원 엔티티 설계

### DIFF
--- a/myboard/build.gradle
+++ b/myboard/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '1.8'
+sourceCompatibility = '18'
 
 configurations {
 	compileOnly {

--- a/myboard/src/main/java/com/example/myboard/MyboardApplication.java
+++ b/myboard/src/main/java/com/example/myboard/MyboardApplication.java
@@ -2,7 +2,9 @@ package com.example.myboard;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class MyboardApplication {
 

--- a/myboard/src/main/java/com/example/myboard/domain/BaseTimeEntity.java
+++ b/myboard/src/main/java/com/example/myboard/domain/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.example.myboard.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    @Column(updatable = true)
+    private LocalDateTime lastModifiedDate;
+}

--- a/myboard/src/main/java/com/example/myboard/domain/member/MemberEntity.java
+++ b/myboard/src/main/java/com/example/myboard/domain/member/MemberEntity.java
@@ -1,0 +1,59 @@
+package com.example.myboard.domain.member;
+
+import com.example.myboard.domain.BaseTimeEntity;
+import lombok.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import javax.persistence.*;
+
+@Table(name = "MEMBER")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@AllArgsConstructor
+@Builder
+public class MemberEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(nullable = false, length = 30, unique = true)
+    private String username;
+
+    private String password;
+
+    @Column(nullable = false, length = 30)
+    private String name;
+
+    @Column(nullable = false, length = 30)
+    private String nickName;
+
+    @Column(nullable = false, length = 30)
+    private Integer age;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    public void updatePassword(PasswordEncoder passwordEncoder, String password) {
+        this.password = passwordEncoder.encode(password);
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateNickname(String nickName) {
+        this.nickName = nickName;
+    }
+
+    public void updateAge(int age) {
+        this.age = age;
+    }
+
+    public void encodePassword(PasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(password);
+    }
+}
+

--- a/myboard/src/main/java/com/example/myboard/domain/member/Role.java
+++ b/myboard/src/main/java/com/example/myboard/domain/member/Role.java
@@ -1,0 +1,5 @@
+package com.example.myboard.domain.member;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/myboard/src/main/java/com/example/myboard/domain/member/repository/MemberRepository.java
+++ b/myboard/src/main/java/com/example/myboard/domain/member/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package com.example.myboard.domain.member.repository;
+
+import com.example.myboard.domain.member.MemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
+
+    Optional<MemberEntity> findByUsername(String username);
+
+    boolean existsByUsername(String username);
+}

--- a/myboard/src/test/java/com/example/myboard/domain/member/repository/MemberRepositoryTest.java
+++ b/myboard/src/test/java/com/example/myboard/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,277 @@
+package com.example.myboard.domain.member.repository;
+
+import com.example.myboard.domain.member.MemberEntity;
+import com.example.myboard.domain.member.Role;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class MemberRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @AfterEach
+    private void after() {
+        em.clear();
+    }
+
+    private void clear() {
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("회원저장 성공")
+    public void success_user_save() throws Exception {
+        var memberEntity = MemberEntity
+                .builder()
+                .username("username")
+                .password("123456789")
+                .name("Member1")
+                .nickName("NickName1")
+                .role(Role.USER)
+                .age(22)
+                .build();
+
+        var saveMemberEntity = memberRepository.save(memberEntity);
+
+        var findMemberEntity = memberRepository.findById(saveMemberEntity.getId()).orElseThrow(RuntimeException::new);
+
+        assertThat(findMemberEntity).isSameAs(saveMemberEntity);
+        assertThat(findMemberEntity).isSameAs(memberEntity);
+    }
+
+    @Test
+    @DisplayName("아이디 없이 회원가입시 오류")
+    public void no_id_when_registering_as_a_member() throws Exception {
+        var memberEntity = MemberEntity
+                .builder()
+                .password("123456789")
+                .name("Member1")
+                .nickName("NickName1")
+                .role(Role.USER)
+                .age(22)
+                .build();
+
+        assertThrows(Exception.class, () -> memberRepository.save(memberEntity));
+    }
+
+    @Test
+    @DisplayName("회원가입시 이름이 없는 오류")
+    public void no_name_when_signing_up() throws Exception {
+        var memberEntity = MemberEntity
+                .builder()
+                .username("username")
+                .password("123456789")
+                .nickName("NickName1")
+                .role(Role.USER)
+                .age(22)
+                .build();
+
+        assertThrows(Exception.class, () -> memberRepository.save(memberEntity));
+    }
+
+    @Test
+    @DisplayName("닉네임 없이 회원가입시 오류")
+    public void no_nickname_when_signing_up() throws Exception {
+        var memberEntity = MemberEntity
+                .builder()
+                .name("Member1")
+                .username("username")
+                .password("123456789")
+                .role(Role.USER)
+                .age(22)
+                .build();
+
+        assertThrows(Exception.class, () -> memberRepository.save(memberEntity));
+    }
+
+    @Test
+    @DisplayName("나이가 없이 회원가입 오류")
+    public void no_age_when_signing_up() throws Exception {
+        var memberEntity = MemberEntity
+                .builder()
+                .username("username")
+                .password("123456789")
+                .name("Member1")
+                .nickName("NickName1")
+                .role(Role.USER)
+                .build();
+
+        assertThrows(Exception.class, () -> memberRepository.save(memberEntity));
+    }
+
+    @Test
+    @DisplayName("중복 아이디 회원가입 오류")
+    public void duplicate_id_signing_up() throws Exception {
+        var memberEntity1 = MemberEntity
+                .builder()
+                .username("username")
+                .password("123456789")
+                .name("Member1")
+                .nickName("NickName1")
+                .role(Role.USER)
+                .age(22)
+                .build();
+
+        var memberEntity2 = MemberEntity
+                .builder()
+                .username("username")
+                .password("987654321")
+                .name("Member2")
+                .nickName("NickName2")
+                .role(Role.USER)
+                .age(22)
+                .build();
+
+        memberRepository.save(memberEntity1);
+        clear();
+
+        assertThrows(Exception.class, () -> memberRepository.save(memberEntity2));
+    }
+
+    @Test
+    @DisplayName("회원정보 수정 성공")
+    public void success_update_user() throws Exception {
+        var memberEntity = MemberEntity
+                .builder()
+                .username("username")
+                .password("123456789")
+                .name("Member1")
+                .nickName("NickName1")
+                .role(Role.USER)
+                .age(22)
+                .build();
+
+        memberRepository.save(memberEntity);
+        clear();
+
+        var updatePassword = "updatePassword";
+        var updateName = "updateName";
+        var updateNickName = "updateNickName";
+        int updateAge = 33;
+
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+        var findMemberEntity = memberRepository.findById(memberEntity.getId()).orElseThrow(Exception::new);
+        findMemberEntity.updateAge(updateAge);
+        findMemberEntity.updateNickname(updateNickName);
+        findMemberEntity.updateName(updateName);
+        findMemberEntity.updatePassword(passwordEncoder, updatePassword);
+        em.flush();
+
+        var findUpdateMemberEntity = memberRepository.findById(findMemberEntity.getId()).orElseThrow(Exception::new);
+
+        assertThat(findUpdateMemberEntity).isSameAs(findMemberEntity);
+        assertThat(passwordEncoder.matches(updatePassword, findUpdateMemberEntity.getPassword())).isTrue();
+        assertThat(findUpdateMemberEntity.getName()).isEqualTo(updateName);
+        assertThat(findUpdateMemberEntity.getName()).isNotEqualTo(memberEntity.getName());
+    }
+
+    @Test
+    @DisplayName("회원 삭제 성공")
+    public void success_delete_user() {
+        var memberEntity = MemberEntity
+                .builder()
+                .username("username")
+                .password("123456789")
+                .name("Member1")
+                .nickName("NickName1")
+                .role(Role.USER)
+                .age(22)
+                .build();
+
+        memberRepository.save(memberEntity);
+        clear();
+
+        memberRepository.delete(memberEntity);
+        clear();
+
+        assertThrows(Exception.class, () -> memberRepository.findById(memberEntity.getId()).orElseThrow(Exception::new));
+    }
+
+    @Test
+    @DisplayName("중복 닉네임 검사 함수 정상 작동 체크")
+    public void exist_by_username_is_success() {
+        var username = "username";
+        var memberEntity = MemberEntity
+                .builder()
+                .username("username")
+                .password("123456789")
+                .name("Member1")
+                .nickName("NickName1")
+                .role(Role.USER)
+                .age(22)
+                .build();
+
+        memberRepository.save(memberEntity);
+        clear();
+
+        assertThat(memberRepository.existsByUsername(username)).isTrue();
+        assertThat(memberRepository.existsByUsername(username + "123")).isFalse();
+    }
+
+    @Test
+    @DisplayName("findByUsername 정상작동 테스트")
+    public void find_by_username_is_success() {
+        var username = "username";
+        var memberEntity = MemberEntity
+                .builder()
+                .username("username")
+                .password("123456789")
+                .name("Member1")
+                .nickName("NickName1")
+                .role(Role.USER)
+                .age(22)
+                .build();
+
+        memberRepository.save(memberEntity);
+        clear();
+
+        assertThat(memberRepository.findByUsername(username).get().getUsername()).isEqualTo(memberEntity.getUsername());
+        assertThat(memberRepository.findByUsername(username).get().getName()).isEqualTo(memberEntity.getName());
+        assertThat(memberRepository.findByUsername(username).get().getId()).isEqualTo(memberEntity.getId());
+        assertThrows(Exception.class,
+                () -> memberRepository.findByUsername(username + "123")
+                        .orElseThrow(Exception::new)
+        );
+    }
+
+    @Test
+    @DisplayName("회원가입시 생성시간 등록 테스트")
+    public void create_time_is_success() throws Exception {
+        var memberEntity = MemberEntity
+                .builder()
+                .username("username")
+                .password("123456789")
+                .name("Member1")
+                .nickName("NickName1")
+                .role(Role.USER)
+                .age(22)
+                .build();
+
+        memberRepository.save(memberEntity);
+        clear();
+
+        var findMemberEntity = memberRepository.findById(memberEntity.getId()).orElseThrow(Exception::new);
+
+        assertThat(findMemberEntity.getCreatedDate()).isNotNull();
+        assertThat(findMemberEntity.getLastModifiedDate()).isNotNull();
+    }
+}


### PR DESCRIPTION
- MemberEntity 생성 : 아이디, 비밀번호, 별명, 나이, 권한으로 설계
- MemberRepository 생성 : 아이디로 MemberEntity를 가져오는 함수 생성, 아이디가 이미 존재하는지 유무를 파악하는 함수 생성
- BaseTimeEntity 생성 : createTime 과 updateTime 을 전역으로 사용하기 위해 생성, Auditing 사용(JPA에서 시간에 대해서 자동으로 값을 넣어주는 기능)
- MemberRepositoryTest 생성 : 회원저장 성공, 아이디 없이 회원가입 오류, 이름없이 회원가입 오류, 닉네임 없이 회원가입 오류, 나이 없이 회원가입 오류, 중복 아이디 회원가입 오류, 회원 정보 수정 성공, 회원 삭제 성공, 중복 닉네임 검사 함수 정상 작동 여부, findByUsername 정상작동 여부, 회원가입시 생성시간 등록 테스트 완료
- java 최신 버전으로 변경 : 1.8 -> 18